### PR TITLE
Add initial chips config and top bar with help button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target
 .vscode
 .parcel-cache
 .cache
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,9 @@ lazy val ringgame =
       scalaVersion := "3.1.1",
       organization := "io.github.jisantuc",
       libraryDependencies ++= Seq(
-        "io.indigoengine" %%% "tyrian" % "0.3.2",
-        "org.scalameta"   %%% "munit"  % "0.7.29" % Test
+        "dev.optics"      %%% "monocle-core" % "3.1.0",
+        "io.indigoengine" %%% "tyrian"       % "0.3.2",
+        "org.scalameta"   %%% "munit"        % "0.7.29" % Test
       ),
       testFrameworks += new TestFramework("munit.Framework"),
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
@@ -40,7 +41,11 @@ lazy val ringgame =
       logo := "ring-game (v" + version.value + ")",
       usefulTasks := Seq(
         UsefulTask("", "fastOptJS", "Rebuild the JS (use during development)"),
-        UsefulTask("", "fullOptJS", "Rebuild the JS and optimise (use in production)"),
+        UsefulTask(
+          "",
+          "fullOptJS",
+          "Rebuild the JS and optimise (use in production)"
+        ),
         UsefulTask("", "code", "Launch VSCode")
       ),
       logoColor        := scala.Console.MAGENTA,

--- a/src/main/scala/io/github/jisantuc/ringgame/GameState.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/GameState.scala
@@ -1,4 +1,0 @@
-package io.github.jisantuc.ringgame
-
-sealed abstract class GameState
-case object AddPlayers extends GameState

--- a/src/main/scala/io/github/jisantuc/ringgame/Msg.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/Msg.scala
@@ -7,3 +7,6 @@ final case class AddPlayer()                            extends Msg
 final case class UpdatePendingPlayerName(value: String) extends Msg
 final case class RemovePlayer(id: UUID)                 extends Msg
 final case class StartGame()                            extends Msg
+final case class GoHome()                               extends Msg
+final case class ShowHelp()                             extends Msg
+final case class UpdateChipsPerPlayer(diff: Int)        extends Msg

--- a/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
@@ -26,10 +26,8 @@ object RingGame extends TyrianApp[Msg, Model]:
           ),
           Cmd.Empty
         )
-        println(out)
         out
       case UpdatePendingPlayerName(s) =>
-        println(s)
         (
           model.copy(pendingPlayerName = s),
           Cmd.Empty

--- a/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
@@ -10,38 +10,59 @@ import scala.scalajs.js.annotation.*
 object RingGame extends TyrianApp[Msg, Model]:
 
   def init(flags: Map[String, String]): (Model, Cmd[Msg]) =
-    (Model(AddPlayers, Nil, ""), Cmd.Empty)
+    (Model.AddPlayers(Nil, "", 30, false), Cmd.Empty)
 
   def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
-    msg match
-      case AddPlayer() =>
-        val out = (
-          model.copy(
-            players = model.players :+ Player(
-              UUID.randomUUID,
-              model.pendingPlayerName,
-              30
-            ),
-            pendingPlayerName = ""
-          ),
-          Cmd.Empty
-        )
-        out
-      case UpdatePendingPlayerName(s) =>
-        (
-          model.copy(pendingPlayerName = s),
-          Cmd.Empty
-        )
-      case RemovePlayer(id) =>
-        (model.copy(players = model.players.filterNot(_.id == id)), Cmd.Empty)
-      case StartGame() =>
-        (model, Cmd.Empty)
+    model match {
+      case ap @ Model.AddPlayers(_, _, _, _) =>
+        msg match
+          case AddPlayer() =>
+            (
+              Model.addPlayer(
+                Model.Player(
+                  UUID.randomUUID,
+                  ap.pendingPlayerName,
+                  ap.initialChips
+                )
+              )(ap),
+              Cmd.Empty
+            )
+          case UpdatePendingPlayerName(s) =>
+            (
+              ap.copy(pendingPlayerName = s),
+              Cmd.Empty
+            )
+          case RemovePlayer(id) =>
+            (
+              Model.deletePlayer(id)(ap),
+              Cmd.Empty
+            )
+          case StartGame() =>
+            // !! IMPORTANT !!
+            // players should all start with the same number of chips,
+            // even if the config was set differently at the exact moment
+            // they were created
+            (model, Cmd.Empty)
+
+          case GoHome() =>
+            (Model.AddPlayers(Nil, "", ap.initialChips, false), Cmd.Empty)
+
+          case ShowHelp() =>
+            (Model.setShowHelp(!model.showHelp)(model), Cmd.Empty)
+
+          case UpdateChipsPerPlayer(n) =>
+            (Model.updateChipsPerPlayer(n)(ap), Cmd.Empty)
+    }
 
   def view(model: Model): Html[Msg] =
-    model.gameState match {
-      case AddPlayers =>
-        render.playerFormRender(model.players, model.pendingPlayerName)
-    }
+    div(`class` := "flex-container flex-column")(
+      render.topBar,
+      render.help(model.showHelp),
+      model match {
+        case Model.AddPlayers(players, pendingPlayerName, initialChips, _) =>
+          render.gameConfigRender(players, pendingPlayerName, initialChips)
+      }
+    )
 
   def subscriptions(model: Model): Sub[Msg] =
     Sub.Empty

--- a/src/main/scala/io/github/jisantuc/ringgame/render.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/render.scala
@@ -1,5 +1,6 @@
 package io.github.jisantuc.ringgame
 
+import tyrian.Attr
 import tyrian.Html
 import tyrian.Html.*
 
@@ -20,25 +21,68 @@ object render {
       )
     )
 
-  private def renderPlayerLine(player: Player): Html[Msg] =
+  private def renderPlayerLine(player: Model.Player): Html[Msg] =
     div(`class` := "flex-container flex-row")(
       text(player.name),
       button(onClick(RemovePlayer(player.id)))(text("❌"))
     )
 
-  def playerFormRender(
-      players: List[Player],
-      pendingPlayerName: String
+  private def initialChipsConfig(chips: Int): Html[Msg] =
+    div(`class` := "flex-container flex-row")(
+      text("Initial chips per player:"),
+      div(style("max-width", "60px"), `class` := "flex-container flex-row")(
+        button(onClick(UpdateChipsPerPlayer(-1)))("-"),
+        text(chips.toString),
+        button(onClick(UpdateChipsPerPlayer(1)))("+")
+      )
+    )
+
+  def gameConfigRender(
+      players: List[Model.Player],
+      pendingPlayerName: String,
+      initialChips: Int
   ): Html[Msg] =
     div(`class` := "flex-container flex-column")(
-      players.map(renderPlayerLine) :+
+      initialChipsConfig(initialChips) +:
+        players.map(renderPlayerLine) :+
         newPlayerFormLine(pendingPlayerName) :+
         button(
           `class` := "player-form-submit",
           onClick(StartGame()),
-          disabled(players.isEmpty)
+          disabled(players.size < 3)
         )(
           text("Start")
         )
     )
+
+  def help(v: Boolean): Html[Msg] =
+    div(`class` := "help-text", hidden(!v))(
+      p(
+        text("""
+    | A ring game is a game of pool played with more than two people in
+    | which each player attempts to achieve some goal, and players who achieve
+    | the goal are rewarded with chips from each other player.
+    |
+    | You can see an example banks ring game""".trim.stripMargin ++ " "),
+        a(href := "https://www.youtube.com/watch?v=itlmp8Bajus")(
+          text("at the 2022 Derby City Classic")
+        ),
+        text("""
+        | . In the example, players are playing 9 ball banks -- each player who successfully makes a
+        | called bank is given a chip by each other player, with the number of chips per bank
+        | increasing each round. You can read more about different ring game versions
+        | on""".trim.stripMargin ++ " "),
+        a(
+          href := "http://www.billiardsforum.com/pool-rules/billiards-ring-game-rules"
+        )(
+          text("this Billiards Forum page")
+        ),
+        text(".")
+      )
+    )
+
+  def topBar: Html[Msg] = div(`class` := "flex-container flex-row")(
+    button(onClick(GoHome()))("Home"),
+    button(onClick(ShowHelp()))("❓")
+  )
 }


### PR DESCRIPTION
This PR adds a top bar with a help button that explains ring games and a home button that takes you back to the game config form. It also adds the ability to configure how many chips everyone starts with.

Closes #2 