### PR TITLE
add simple sparkline showing score history

### DIFF
--- a/ring-game.css
+++ b/ring-game.css
@@ -23,7 +23,8 @@
     text-align: center;
     row-gap: 0.5rem;
     min-width: 180px;
-    padding: 0;
+    align-items: center;
+    margin: 1rem;
 }
 
 .player-input-line {
@@ -48,4 +49,29 @@ body {
 
 .padded {
     padding: 1rem;
+}
+
+.line-chart {
+    width: 100%;
+    height: 100%;
+    stroke: blue;
+    fill: none;
+    stroke-width: 3;
+}
+
+.sparkline-container {
+    min-height: 5rem;
+    min-width: 15rem;
+    max-height: 10rem;
+    width: 66%;
+    margin: 1rem;
+}
+
+.tappable {
+    touch-action: manipulation;
+}
+
+.award-button {
+    margin: 1rem;
+    width: 90%
 }

--- a/src/main/scala/io/github/jisantuc/ringgame/Model.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/Model.scala
@@ -20,13 +20,15 @@ object Model {
 
   final case class Play(
       players: List[Player],
+      initialChips: Int,
       showHelp: Boolean
   ) extends Model
 
   final case class Player(
       id: UUID,
       name: String,
-      chips: Int
+      chips: Int,
+      history: List[Int]
   )
 
   final case class PendingPlayer(
@@ -39,7 +41,7 @@ object Model {
     {
       case ap @ AddPlayers(_, _, _, _) =>
         ap.copy(showHelp = b)
-      case p @ Play(_, _) => p.copy(showHelp = b)
+      case p @ Play(_, _, _) => p.copy(showHelp = b)
     }
   }
 

--- a/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/RingGame.scala
@@ -29,7 +29,8 @@ object RingGame extends TyrianApp[Msg, Model]:
                 Model.Player(
                   UUID.randomUUID,
                   ap.pendingPlayerName,
-                  ap.initialChips
+                  ap.initialChips,
+                  Nil
                 )
               )(ap),
               Cmd.Empty
@@ -46,7 +47,7 @@ object RingGame extends TyrianApp[Msg, Model]:
             )
           case StartGame() =>
             val equalized = Model.equalizeChips(ap)
-            (Model.Play(equalized.players, false), Cmd.Empty)
+            (Model.Play(equalized.players, ap.initialChips, false), Cmd.Empty)
 
           case GoHome() =>
             homeTransition(ap.initialChips)
@@ -59,7 +60,7 @@ object RingGame extends TyrianApp[Msg, Model]:
           // AwardChips doesn't make sense in the player form state
           // NoOp should always do nothing
           case NoOp | AwardChips(_, _) => (ap, Cmd.Empty)
-      case p @ Model.Play(_, _) =>
+      case p @ Model.Play(_, _, _) =>
         msg match {
           case GoHome() =>
             // initialChips doesn't need to be tracked in the play state,
@@ -89,8 +90,8 @@ object RingGame extends TyrianApp[Msg, Model]:
       model match {
         case Model.AddPlayers(players, pendingPlayerName, initialChips, _) =>
           render.gameConfigRender(players, pendingPlayerName, initialChips)
-        case Model.Play(players, showHelp) =>
-          render.playRender(players, showHelp)
+        case Model.Play(players, initialChips, showHelp) =>
+          render.playRender(players, initialChips, showHelp)
       }
     )
 

--- a/src/main/scala/io/github/jisantuc/ringgame/chart.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/chart.scala
@@ -1,0 +1,78 @@
+package io.github.jisantuc.ringgame
+
+import tyrian.Html
+import tyrian.Html.*
+
+object chart {
+
+  private def viewBox(xMax: Int, yMax: Int) =
+    attribute("viewBox", s"0 0 $xMax $yMax")
+
+  private def countingLine[T](
+      heights: List[Int],
+      default: Int,
+      domainXMax: Int,
+      domainYMax: Int,
+      xMax: Int,
+      yMax: Int
+  ) =
+    val nTicks = heights.size.toDouble
+
+    val percentages = heights
+      .map(_ / domainYMax.toDouble)
+      .zipWithIndex
+      .map { case (y, x) =>
+        (
+          xMax * x / nTicks,
+          (yMax - 20) * (1 - y)
+        )
+      }
+
+    tag[T]("polyline")(
+      attribute(
+        "points",
+        percentages
+          .map { case (xTick, height) =>
+            s"$xTick,${height}"
+          }
+          .mkString(" ")
+      ),
+      attribute(
+        "transform",
+        "translate(0, 10)"
+      )
+    )(Nil)
+
+  /** Create an SVG chart of a sequence of integer values
+    * @param yMax
+    *   a hardcoded maximum value for the y axis
+    * @param fillXTo
+    *   a hardcoded minimum value for the number of x ticks
+    * @param values
+    *   the data to plot
+    * @param xBuffer
+    *   the number of extra x ticks to render
+    */
+  def countingLineChart[T](
+      totalChips: Int,
+      initialChips: Int,
+      values: List[Int]
+  ): Html[T] =
+    val chartXMax = 1200
+    val chartYMax = 400
+    div(`class` := "flex-container flex-row sparkline-container")(
+      svg(
+        `class` := "line-chart flex-row",
+        viewBox(chartXMax, chartYMax)
+      )(
+        countingLine[T](
+          values,
+          initialChips,
+          values.size,
+          totalChips,
+          chartXMax,
+          chartYMax
+        )
+      )
+    )
+}

--- a/src/main/scala/io/github/jisantuc/ringgame/payout.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/payout.scala
@@ -15,7 +15,15 @@ object payout {
       else acc + (chipsEarned `min` player.chips)
     )
     players.map { player =>
-      if player.id == earningPlayer then player.focus(_.chips).modify(_ + pot)
-      else player.focus(_.chips).modify(chips => (chips - chipsEarned) `max` 0)
+      val withPayout =
+        if player.id == earningPlayer then
+          player
+            .focus(_.chips)
+            .modify(_ + pot)
+        else
+          player
+            .focus(_.chips)
+            .modify(chips => (chips - chipsEarned) `max` 0)
+      withPayout.focus(_.history).modify(history => history :+ withPayout.chips)
     }
 }

--- a/src/main/scala/io/github/jisantuc/ringgame/render.scala
+++ b/src/main/scala/io/github/jisantuc/ringgame/render.scala
@@ -41,12 +41,12 @@ object render {
         `class` := "flex-container flex-row padded"
       )(
         button(
-          `class` := "chip-count-config padded",
+          `class` := "chip-count-config padded tappable",
           onClick(UpdateChipsPerPlayer(-1))
         )("➖"),
         text(chips.toString),
         button(
-          `class` := "chip-count-config padded",
+          `class` := "chip-count-config padded tappable",
           onClick(UpdateChipsPerPlayer(1))
         )("➕")
       )
@@ -101,22 +101,37 @@ object render {
     button(`class` := "big-text padded", onClick(ShowHelp()))("❓")
   )
 
-  inline private def playerCard(player: Model.Player): Html[Msg] =
+  inline private def playerCard(
+      player: Model.Player,
+      totalChips: Int,
+      initialChips: Int
+  ): Html[Msg] =
     div(
-      `class` := "flex-container flex-column player-card padded"
+      `class` := "flex-container flex-column player-card"
     )(
       h1(`class` := "big-text padded")(player.name),
       h3(`class` := "big-text padded")(s"${player.chips} chips"),
-      button(`class` := "big-text padded", onClick(AwardChips(player.id, 1)))(
+      chart.countingLineChart(totalChips, initialChips, player.history),
+      button(
+        `class` := "big-text padded tappable award-button",
+        onClick(AwardChips(player.id, 1))
+      )(
         "Award"
       )
     )
 
-  def playRender(players: List[Model.Player], showHelp: Boolean): Html[Msg] =
+  def playRender(
+      players: List[Model.Player],
+      initialChips: Int,
+      showHelp: Boolean
+  ): Html[Msg] =
+    val totalChips = players.map(_.chips).sum
     div(
       `class` := "flex-container flex-column padded",
       style("flex-wrap", "wrap")
     )(
-      players.map(playerCard(_))
+      div(
+        players.map(playerCard(_, totalChips, initialChips))
+      )
     )
 }

--- a/src/test/scala/io/github/jisantuc/ringgame/RingGameTests.scala
+++ b/src/test/scala/io/github/jisantuc/ringgame/RingGameTests.scala
@@ -18,9 +18,9 @@ class RingGameTests extends munit.FunSuite {
     )
 
   val richPlayers = List(
-    Model.Player(UUID.randomUUID, "p1", 30),
-    Model.Player(UUID.randomUUID, "p2", 30),
-    Model.Player(UUID.randomUUID, "p3", 30)
+    Model.Player(UUID.randomUUID, "p1", 30, Nil),
+    Model.Player(UUID.randomUUID, "p2", 30, Nil),
+    Model.Player(UUID.randomUUID, "p3", 30, Nil)
   )
 
   val p1 = richPlayers(0)
@@ -40,9 +40,9 @@ class RingGameTests extends munit.FunSuite {
 
   test("bankrupt one player") {
     val players = List(
-      Model.Player(UUID.randomUUID, "p1", 1),
-      Model.Player(UUID.randomUUID, "p2", 20),
-      Model.Player(UUID.randomUUID, "p3", 25)
+      Model.Player(UUID.randomUUID, "p1", 1, Nil),
+      Model.Player(UUID.randomUUID, "p2", 20, Nil),
+      Model.Player(UUID.randomUUID, "p3", 25, Nil)
     )
 
     val p1 = players(0)
@@ -58,14 +58,58 @@ class RingGameTests extends munit.FunSuite {
 
   test("chip equalization equalizes chip counts") {
     val players = List(
-      Model.Player(UUID.randomUUID, "p1", 1),
-      Model.Player(UUID.randomUUID, "p2", 20),
-      Model.Player(UUID.randomUUID, "p3", 25)
+      Model.Player(UUID.randomUUID, "p1", 1, Nil),
+      Model.Player(UUID.randomUUID, "p2", 20, Nil),
+      Model.Player(UUID.randomUUID, "p3", 25, Nil)
     )
     val equalized =
       Model.equalizeChips(Model.AddPlayers(players, "", 30, false))
     equalized.players.map(player =>
       expectChipsForPlayer(30, player.id, equalized.players)
+    )
+  }
+
+  test("earning chips preserves history") {
+    val players = List(
+      Model.Player(UUID.randomUUID, "p1", 1, Nil),
+      Model.Player(UUID.randomUUID, "p2", 20, Nil),
+      Model.Player(UUID.randomUUID, "p3", 25, Nil)
+    )
+
+    val p1 = players(0)
+    val p2 = players(1)
+
+    val postPayout  = payout.earnChips(1, p1.id, players)
+    val postPayout2 = payout.earnChips(1, p2.id, postPayout)
+
+    // we should append to an empty history
+    assertEquals(
+      postPayout.map(_.history),
+      List(
+        List(3),
+        List(19),
+        List(24)
+      )
+    )
+
+    // we should append correct values to a nonempty history
+    assertEquals(
+      postPayout2.map(_.history),
+      List(
+        List(3, 2),
+        List(19, 21),
+        List(24, 23)
+      )
+    )
+
+    // numbers of chips should also be correct
+    assertEquals(
+      postPayout2.map(_.chips),
+      List(
+        2,
+        21,
+        23
+      )
     )
   }
 


### PR DESCRIPTION
This PR adds a simple sparkline-ish chart showing how players' chip counts have evolved over time. There are no axes or anything, the chart is just meant to give a general impression of `*waves hands*` recent trends

![chips](https://user-images.githubusercontent.com/5702984/164948780-332089d4-813c-4171-a654-2db515183cea.jpg)

Closes #10 